### PR TITLE
display bumped version number if successful

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -38,8 +38,9 @@ if (!ignore) {
   }
 }
 
-bumpy(process.cwd(), release, function (err) {
+bumpy(process.cwd(), release, function (err, version) {
   if (err) return error(err.message);
+  if (version) console.log(version);
 });
 
 


### PR DESCRIPTION
makes it easier to use in the scripts
also return an error if bumping versions would result in an inconsistent
version number
